### PR TITLE
Split conf, skip reply

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,12 +48,16 @@ EXTRA_DIST = drool.1.in \
 
 bin_PROGRAMS = drool
 
-drool_SOURCES = callback.c client.c client_pool.c conf.c drool.c dropback.c log.c query.c socket_pool.c stats_callback.c \
+drool_SOURCES = callback.c client.c client_pool.c \
+    conf.c conf_client_pool.c conf_file.c conf_interface.c \
+    drool.c dropback.c log.c query.c socket_pool.c stats_callback.c \
     omg-dns/omg_dns.c \
     parseconf/parseconf.c \
     pcap-thread/pcap_thread.c \
     sllq/sllq.c
-dist_drool_SOURCES = callback.h client.h client_pool.h conf.h drool.h dropback.h log.h query.h socket_pool.h stats_callback.h timing.h \
+dist_drool_SOURCES = callback.h client.h client_pool.h \
+    conf.h conf_client_pool.h conf_file.h conf_interface.h \
+    drool.h dropback.h log.h query.h socket_pool.h stats_callback.h timing.h \
     omg-dns/omg_dns.h \
     parseconf/parseconf.h \
     pcap-thread/pcap_thread.h \

--- a/src/client.c
+++ b/src/client.c
@@ -166,6 +166,11 @@ static void client_write(struct ev_loop* loop, ev_io* w, int revents) {
     }
 
     ev_io_stop(loop, w);
+    if (client->skip_reply) {
+        client->state = CLIENT_SUCCESS;
+        client->callback(client, loop);
+        return;
+    }
     ev_io_start(loop, &(client->read_watcher));
     client->state = CLIENT_RECIVING;
     return;
@@ -342,6 +347,17 @@ int client_set_start(drool_client_t* client, ev_tstamp start) {
     }
 
     client->start = start;
+
+    return 0;
+}
+
+int client_set_skip_reply(drool_client_t* client) {
+    drool_assert(client);
+    if (!client) {
+        return 1;
+    }
+
+    client->skip_reply = 1;
 
     return 0;
 }

--- a/src/client.h
+++ b/src/client.h
@@ -70,6 +70,7 @@ struct drool_client {
     unsigned short  have_from_addr : 1;
     unsigned short  have_fd : 1;
     unsigned short  is_connected : 1;
+    unsigned short  skip_reply : 1;
 
     ev_tstamp               start;
     drool_client_t*         next;
@@ -106,6 +107,7 @@ int client_set_next(drool_client_t* client, drool_client_t* next);
 int client_set_prev(drool_client_t* client, drool_client_t* prev);
 int client_set_fd(drool_client_t* client, int fd);
 int client_set_start(drool_client_t* client, ev_tstamp start);
+int client_set_skip_reply(drool_client_t* client);
 
 int client_connect(drool_client_t* client, int ipproto, const struct sockaddr* addr, socklen_t addlen, struct ev_loop* loop);
 int client_connect_fd(drool_client_t* client, int fd, const struct sockaddr* addr, socklen_t addlen, struct ev_loop* loop);

--- a/src/client_pool.c
+++ b/src/client_pool.c
@@ -372,7 +372,9 @@ static void client_pool_engine_query(struct ev_loop* loop, ev_async* w, int reve
         else
 #endif
         if ((client = client_new(query, &client_pool_client_callback))
-            && !client_set_start(client, ev_now(loop)))
+            && !client_set_start(client, ev_now(loop))
+            && (!conf_client_pool_skip_reply(conf_client_pool(client_pool->conf))
+                || !client_set_skip_reply(client)))
         {
 #ifdef DROOL_CLIENT_POOL_ENABLE_SOCKET_POOL
             int fd;

--- a/src/conf.c
+++ b/src/conf.c
@@ -45,284 +45,6 @@
 #include <string.h>
 #include <stdio.h>
 
-/*
- * conf file
- */
-
-drool_conf_file_t* conf_file_new(void) {
-    drool_conf_file_t* conf_file = calloc(1, sizeof(drool_conf_file_t));
-    return conf_file;
-}
-
-void conf_file_free(drool_conf_file_t* conf_file) {
-    if (conf_file) {
-        conf_file_release(conf_file);
-        free(conf_file);
-    }
-}
-
-void conf_file_release(drool_conf_file_t* conf_file) {
-    if (conf_file) {
-        if (conf_file->name) {
-            free(conf_file->name);
-            conf_file->name = 0;
-        }
-    }
-}
-
-inline const drool_conf_file_t* conf_file_next(const drool_conf_file_t* conf_file) {
-    drool_assert(conf_file);
-    return conf_file->next;
-}
-
-int conf_file_set_next(drool_conf_file_t* conf_file, drool_conf_file_t* next) {
-    if (!conf_file) {
-        return CONF_EINVAL;
-    }
-    if (!next) {
-        return CONF_EINVAL;
-    }
-
-    conf_file->next = next;
-
-    return CONF_OK;
-}
-
-inline const char* conf_file_name(const drool_conf_file_t* conf_file) {
-    drool_assert(conf_file);
-    return conf_file->name;
-}
-
-int conf_file_set_name(drool_conf_file_t* conf_file, const char* name, size_t length) {
-    if (!conf_file) {
-        return CONF_EINVAL;
-    }
-    if (!name) {
-        return CONF_EINVAL;
-    }
-
-    if (conf_file->name) {
-        free(conf_file->name);
-    }
-    if (length) {
-        if (!(conf_file->name = strndup(name, length))) {
-            return CONF_ENOMEM;
-        }
-    }
-    else {
-        if (!(conf_file->name = strdup(name))) {
-            return CONF_ENOMEM;
-        }
-    }
-    printf("name: %s\n", conf_file->name);
-
-    return CONF_OK;
-}
-
-/*
- * conf interface
- */
-
-drool_conf_interface_t* conf_interface_new(void) {
-    drool_conf_interface_t* conf_interface = calloc(1, sizeof(drool_conf_interface_t));
-    return conf_interface;
-}
-
-void conf_interface_free(drool_conf_interface_t* conf_interface) {
-    if (conf_interface) {
-        conf_interface_release(conf_interface);
-        free(conf_interface);
-    }
-}
-
-void conf_interface_release(drool_conf_interface_t* conf_interface) {
-    if (conf_interface) {
-        if (conf_interface->name) {
-            free(conf_interface->name);
-            conf_interface->name = 0;
-        }
-    }
-}
-
-inline const drool_conf_interface_t* conf_interface_next(const drool_conf_interface_t* conf_interface) {
-    drool_assert(conf_interface);
-    return conf_interface->next;
-}
-
-int conf_interface_set_next(drool_conf_interface_t* conf_interface, drool_conf_interface_t* next) {
-    if (!conf_interface) {
-        return CONF_EINVAL;
-    }
-    if (!next) {
-        return CONF_EINVAL;
-    }
-
-    conf_interface->next = next;
-
-    return CONF_OK;
-}
-
-inline const char* conf_interface_name(const drool_conf_interface_t* conf_interface) {
-    drool_assert(conf_interface);
-    return conf_interface->name;
-}
-
-int conf_interface_set_name(drool_conf_interface_t* conf_interface, const char* name, size_t length) {
-    if (!conf_interface) {
-        return CONF_EINVAL;
-    }
-    if (!name) {
-        return CONF_EINVAL;
-    }
-
-    if (conf_interface->name) {
-        free(conf_interface->name);
-    }
-    if (length) {
-        if (!(conf_interface->name = strndup(name, length))) {
-            return CONF_ENOMEM;
-        }
-    }
-    else {
-        if (!(conf_interface->name = strdup(name))) {
-            return CONF_ENOMEM;
-        }
-    }
-
-    return CONF_OK;
-}
-
-/*
- * conf client_pool
- */
-
-drool_conf_client_pool_t* conf_client_pool_new(void) {
-    drool_conf_client_pool_t* conf_client_pool = calloc(1, sizeof(drool_conf_client_pool_t));
-    return conf_client_pool;
-}
-
-void conf_client_pool_free(drool_conf_client_pool_t* conf_client_pool) {
-    if (conf_client_pool) {
-        if (conf_client_pool->target_host)
-            free(conf_client_pool->target_host);
-        if (conf_client_pool->target_service)
-            free(conf_client_pool->target_service);
-        free(conf_client_pool);
-    }
-}
-
-int conf_client_pool_have_target(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->have_target;
-}
-
-int conf_client_pool_have_max_clients(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->have_max_clients;
-}
-
-int conf_client_pool_have_client_ttl(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->have_client_ttl;
-}
-
-const drool_conf_client_pool_t* conf_client_pool_next(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->next;
-}
-
-const char* conf_client_pool_target_host(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->target_host;
-}
-
-const char* conf_client_pool_target_service(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->target_service;
-}
-
-size_t conf_client_pool_max_clients(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->max_clients;
-}
-
-double conf_client_pool_client_ttl(const drool_conf_client_pool_t* conf_client_pool) {
-    drool_assert(conf_client_pool);
-    return conf_client_pool->client_ttl;
-}
-
-int conf_client_pool_set_next(drool_conf_client_pool_t* conf_client_pool, drool_conf_client_pool_t* next) {
-    if (!conf_client_pool) {
-        return CONF_EINVAL;
-    }
-    if (!next) {
-        return CONF_EINVAL;
-    }
-
-    conf_client_pool->next = next;
-
-    return CONF_OK;
-}
-
-int conf_client_pool_set_target(drool_conf_client_pool_t* conf_client_pool, const char* host, size_t host_length, const char* service, size_t service_length) {
-    if (!conf_client_pool) {
-        return CONF_EINVAL;
-    }
-    if (!host) {
-        return CONF_EINVAL;
-    }
-    if (!host_length) {
-        return CONF_EINVAL;
-    }
-    if (!service) {
-        return CONF_EINVAL;
-    }
-    if (!service_length) {
-        return CONF_EINVAL;
-    }
-
-    if (conf_client_pool->target_host)
-        free(conf_client_pool->target_host);
-    if (conf_client_pool->target_service)
-        free(conf_client_pool->target_service);
-    conf_client_pool->have_target = 0;
-    if (!(conf_client_pool->target_host = strndup(host, host_length))) {
-        return CONF_ENOMEM;
-    }
-    if (!(conf_client_pool->target_service = strndup(service, service_length))) {
-        return CONF_ENOMEM;
-    }
-    conf_client_pool->have_target = 1;
-
-    return CONF_OK;
-}
-
-int conf_client_pool_set_max_clients(drool_conf_client_pool_t* conf_client_pool, size_t max_clients) {
-    if (!conf_client_pool) {
-        return CONF_EINVAL;
-    }
-
-    conf_client_pool->max_clients = max_clients;
-    conf_client_pool->have_max_clients = 1;
-
-    return CONF_OK;
-}
-
-int conf_client_pool_set_client_ttl(drool_conf_client_pool_t* conf_client_pool, double client_ttl) {
-    if (!conf_client_pool) {
-        return CONF_EINVAL;
-    }
-
-    conf_client_pool->client_ttl = client_ttl;
-    conf_client_pool->have_client_ttl = 1;
-
-    return CONF_OK;
-}
-
-/*
- * conf
- */
-
 drool_conf_t* conf_new(void) {
     drool_conf_t* conf = calloc(1, sizeof(drool_conf_t));
     return conf;
@@ -808,6 +530,20 @@ static int parse_client_pool_client_ttl(void* user, const parseconf_token_t* tok
     return conf_client_pool_set_client_ttl(&(conf->client_pool), client_ttl);
 }
 
+static parseconf_token_type_t client_pool_skip_reply_tokens[] = {
+    PARSECONF_TOKEN_FLOAT, PARSECONF_TOKEN_END
+};
+
+static int parse_client_pool_skip_reply(void* user, const parseconf_token_t* tokens, const char** errstr) {
+    drool_conf_t* conf = (drool_conf_t*)user;
+
+    if (!conf) {
+        return 1;
+    }
+
+    return conf_client_pool_set_skip_reply(&(conf->client_pool));
+}
+
 static parseconf_syntax_t client_pool_syntax[] = {
     /* client_pool target <host> <port>; */
     { "target", parse_client_pool_target, client_pool_target_tokens, 0 },
@@ -815,6 +551,8 @@ static parseconf_syntax_t client_pool_syntax[] = {
     { "max_clients", parse_client_pool_max_clients, client_pool_max_clients_tokens, 0 },
     /* client_pool client_ttl <float>; */
     { "client_ttl", parse_client_pool_client_ttl, client_pool_client_ttl_tokens, 0 },
+    /* client_pool skip_reply; */
+    { "skip_reply", parse_client_pool_skip_reply, client_pool_skip_reply_tokens, 0 },
     PARSECONF_SYNTAX_END
 };
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -37,11 +37,14 @@
 
 #include "log.h"
 #include "timing.h"
+#include "conf_file.h"
+#include "conf_interface.h"
+#include "conf_client_pool.h"
 
 #ifndef __drool_conf_h
 #define __drool_conf_h
 
-#include <sys/types.h>
+#include <stddef.h>
 
 #define CONF_EEXIST     -4
 #define CONF_ENOMEM     -3
@@ -56,86 +59,6 @@
 #define CONF_ENOMEM_STR "Out of memory"
 #define CONF_EINVAL_STR "Invalid arguments"
 #define CONF_ERROR_STR  "Generic error"
-
-/*
- * conf file struct and functions
- */
-
-#define CONF_FILE_T_INIT { 0, 0 }
-typedef struct drool_conf_file drool_conf_file_t;
-struct drool_conf_file {
-    drool_conf_file_t*  next;
-    char*               name;
-};
-
-drool_conf_file_t* conf_file_new(void);
-void conf_file_free(drool_conf_file_t* conf_file);
-void conf_file_release(drool_conf_file_t* conf_file);
-const drool_conf_file_t* conf_file_next(const drool_conf_file_t* conf_file);
-int conf_file_set_next(drool_conf_file_t* conf_file, drool_conf_file_t* next);
-const char* conf_file_name(const drool_conf_file_t* conf_file);
-int conf_file_set_name(drool_conf_file_t* conf_file, const char* name, size_t length);
-
-/*
- * conf interface struct and functions
- */
-
-#define CONF_INTERFACE_T_INIT { 0, 0 }
-typedef struct drool_conf_interface drool_conf_interface_t;
-struct drool_conf_interface {
-    drool_conf_interface_t* next;
-    char*                   name;
-};
-
-drool_conf_interface_t* conf_interface_new(void);
-void conf_interface_free(drool_conf_interface_t* conf_interface);
-void conf_interface_release(drool_conf_interface_t* conf_interface);
-const drool_conf_interface_t* conf_interface_next(const drool_conf_interface_t* conf_interface);
-int conf_interface_set_next(drool_conf_interface_t* conf_interface, drool_conf_interface_t* next);
-const char* conf_interface_name(const drool_conf_interface_t* conf_interface);
-int conf_interface_set_name(drool_conf_interface_t* conf_interface, const char* name, size_t length);
-
-/*
- * conf client_pool struct and functions
- */
-
-#define CONF_CLIENT_POOL_T_INIT { \
-    0, \
-    0, 0, 0, \
-    0, 0, 0, 0 \
-}
-typedef struct drool_conf_client_pool drool_conf_client_pool_t;
-struct drool_conf_client_pool {
-    drool_conf_client_pool_t*   next;
-
-    unsigned short  have_target : 1;
-    unsigned short  have_max_clients : 1;
-    unsigned short  have_client_ttl : 1;
-
-    char*           target_host;
-    char*           target_service;
-    size_t          max_clients;
-    double          client_ttl;
-};
-
-drool_conf_client_pool_t* conf_client_pool_new(void);
-void conf_client_pool_free(drool_conf_client_pool_t* conf_client_pool);
-int conf_client_pool_have_target(const drool_conf_client_pool_t* conf_client_pool);
-int conf_client_pool_have_max_clients(const drool_conf_client_pool_t* conf_client_pool);
-int conf_client_pool_have_client_ttl(const drool_conf_client_pool_t* conf_client_pool);
-const drool_conf_client_pool_t* conf_client_pool_next(const drool_conf_client_pool_t* conf_client_pool);
-const char* conf_client_pool_target_host(const drool_conf_client_pool_t* conf_client_pool);
-const char* conf_client_pool_target_service(const drool_conf_client_pool_t* conf_client_pool);
-size_t conf_client_pool_max_clients(const drool_conf_client_pool_t* conf_client_pool);
-double conf_client_pool_client_ttl(const drool_conf_client_pool_t* conf_client_pool);
-int conf_client_pool_set_next(drool_conf_client_pool_t* conf_client_pool, drool_conf_client_pool_t* next);
-int conf_client_pool_set_target(drool_conf_client_pool_t* conf_client_pool, const char* host, size_t host_length, const char* service, size_t service_length);
-int conf_client_pool_set_max_clients(drool_conf_client_pool_t* conf_client_pool, size_t max_clients);
-int conf_client_pool_set_client_ttl(drool_conf_client_pool_t* conf_client_pool, double client_ttl);
-
-/*
- * conf struct and functions
- */
 
 #define CONF_T_INIT { \
     0, 0, 0, 0, 0, \

--- a/src/conf_client_pool.c
+++ b/src/conf_client_pool.c
@@ -1,0 +1,182 @@
+/*
+ * DNS Reply Tool (drool)
+ *
+ * Copyright (c) 2017, OARC, Inc.
+ * Copyright (c) 2017, Comcast Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "conf.h"
+#include "drool.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+drool_conf_client_pool_t* conf_client_pool_new(void) {
+    drool_conf_client_pool_t* conf_client_pool = calloc(1, sizeof(drool_conf_client_pool_t));
+    return conf_client_pool;
+}
+
+void conf_client_pool_free(drool_conf_client_pool_t* conf_client_pool) {
+    if (conf_client_pool) {
+        if (conf_client_pool->target_host)
+            free(conf_client_pool->target_host);
+        if (conf_client_pool->target_service)
+            free(conf_client_pool->target_service);
+        free(conf_client_pool);
+    }
+}
+
+inline int conf_client_pool_have_target(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->have_target;
+}
+
+inline int conf_client_pool_have_max_clients(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->have_max_clients;
+}
+
+inline int conf_client_pool_have_client_ttl(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->have_client_ttl;
+}
+
+inline const drool_conf_client_pool_t* conf_client_pool_next(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->next;
+}
+
+inline const char* conf_client_pool_target_host(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->target_host;
+}
+
+inline const char* conf_client_pool_target_service(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->target_service;
+}
+
+inline size_t conf_client_pool_max_clients(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->max_clients;
+}
+
+inline double conf_client_pool_client_ttl(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->client_ttl;
+}
+
+inline int conf_client_pool_skip_reply(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->skip_reply;
+}
+
+int conf_client_pool_set_next(drool_conf_client_pool_t* conf_client_pool, drool_conf_client_pool_t* next) {
+    if (!conf_client_pool) {
+        return CONF_EINVAL;
+    }
+    if (!next) {
+        return CONF_EINVAL;
+    }
+
+    conf_client_pool->next = next;
+
+    return CONF_OK;
+}
+
+int conf_client_pool_set_target(drool_conf_client_pool_t* conf_client_pool, const char* host, size_t host_length, const char* service, size_t service_length) {
+    if (!conf_client_pool) {
+        return CONF_EINVAL;
+    }
+    if (!host) {
+        return CONF_EINVAL;
+    }
+    if (!host_length) {
+        return CONF_EINVAL;
+    }
+    if (!service) {
+        return CONF_EINVAL;
+    }
+    if (!service_length) {
+        return CONF_EINVAL;
+    }
+
+    if (conf_client_pool->target_host)
+        free(conf_client_pool->target_host);
+    if (conf_client_pool->target_service)
+        free(conf_client_pool->target_service);
+    conf_client_pool->have_target = 0;
+    if (!(conf_client_pool->target_host = strndup(host, host_length))) {
+        return CONF_ENOMEM;
+    }
+    if (!(conf_client_pool->target_service = strndup(service, service_length))) {
+        return CONF_ENOMEM;
+    }
+    conf_client_pool->have_target = 1;
+
+    return CONF_OK;
+}
+
+int conf_client_pool_set_max_clients(drool_conf_client_pool_t* conf_client_pool, size_t max_clients) {
+    if (!conf_client_pool) {
+        return CONF_EINVAL;
+    }
+
+    conf_client_pool->max_clients = max_clients;
+    conf_client_pool->have_max_clients = 1;
+
+    return CONF_OK;
+}
+
+int conf_client_pool_set_client_ttl(drool_conf_client_pool_t* conf_client_pool, double client_ttl) {
+    if (!conf_client_pool) {
+        return CONF_EINVAL;
+    }
+
+    conf_client_pool->client_ttl = client_ttl;
+    conf_client_pool->have_client_ttl = 1;
+
+    return CONF_OK;
+}
+
+int conf_client_pool_set_skip_reply(drool_conf_client_pool_t* conf_client_pool) {
+    if (!conf_client_pool) {
+        return CONF_EINVAL;
+    }
+
+    conf_client_pool->skip_reply = 1;
+
+    return CONF_OK;
+}

--- a/src/conf_client_pool.h
+++ b/src/conf_client_pool.h
@@ -1,0 +1,80 @@
+/*
+ * DNS Reply Tool (drool)
+ *
+ * Copyright (c) 2017, OARC, Inc.
+ * Copyright (c) 2017, Comcast Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __drool_conf_client_pool_h
+#define __drool_conf_client_pool_h
+
+#include <stddef.h>
+
+#define CONF_CLIENT_POOL_T_INIT { \
+    0, \
+    0, 0, 0, 0, \
+    0, 0, 0, 0 \
+}
+typedef struct drool_conf_client_pool drool_conf_client_pool_t;
+struct drool_conf_client_pool {
+    drool_conf_client_pool_t*   next;
+
+    unsigned short  have_target : 1;
+    unsigned short  have_max_clients : 1;
+    unsigned short  have_client_ttl : 1;
+    unsigned short  skip_reply : 1;
+
+    char*           target_host;
+    char*           target_service;
+    size_t          max_clients;
+    double          client_ttl;
+};
+
+drool_conf_client_pool_t* conf_client_pool_new(void);
+void conf_client_pool_free(drool_conf_client_pool_t* conf_client_pool);
+int conf_client_pool_have_target(const drool_conf_client_pool_t* conf_client_pool);
+int conf_client_pool_have_max_clients(const drool_conf_client_pool_t* conf_client_pool);
+int conf_client_pool_have_client_ttl(const drool_conf_client_pool_t* conf_client_pool);
+const drool_conf_client_pool_t* conf_client_pool_next(const drool_conf_client_pool_t* conf_client_pool);
+const char* conf_client_pool_target_host(const drool_conf_client_pool_t* conf_client_pool);
+const char* conf_client_pool_target_service(const drool_conf_client_pool_t* conf_client_pool);
+size_t conf_client_pool_max_clients(const drool_conf_client_pool_t* conf_client_pool);
+double conf_client_pool_client_ttl(const drool_conf_client_pool_t* conf_client_pool);
+int conf_client_pool_skip_reply(const drool_conf_client_pool_t* conf_client_pool);
+int conf_client_pool_set_next(drool_conf_client_pool_t* conf_client_pool, drool_conf_client_pool_t* next);
+int conf_client_pool_set_target(drool_conf_client_pool_t* conf_client_pool, const char* host, size_t host_length, const char* service, size_t service_length);
+int conf_client_pool_set_max_clients(drool_conf_client_pool_t* conf_client_pool, size_t max_clients);
+int conf_client_pool_set_client_ttl(drool_conf_client_pool_t* conf_client_pool, double client_ttl);
+int conf_client_pool_set_skip_reply(drool_conf_client_pool_t* conf_client_pool);
+
+#endif /* __drool_conf_client_pool_h */

--- a/src/conf_file.c
+++ b/src/conf_file.c
@@ -1,0 +1,113 @@
+/*
+ * DNS Reply Tool (drool)
+ *
+ * Copyright (c) 2017, OARC, Inc.
+ * Copyright (c) 2017, Comcast Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "conf_file.h"
+#include "drool.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+drool_conf_file_t* conf_file_new(void) {
+    drool_conf_file_t* conf_file = calloc(1, sizeof(drool_conf_file_t));
+    return conf_file;
+}
+
+void conf_file_free(drool_conf_file_t* conf_file) {
+    if (conf_file) {
+        conf_file_release(conf_file);
+        free(conf_file);
+    }
+}
+
+void conf_file_release(drool_conf_file_t* conf_file) {
+    if (conf_file) {
+        if (conf_file->name) {
+            free(conf_file->name);
+            conf_file->name = 0;
+        }
+    }
+}
+
+inline const drool_conf_file_t* conf_file_next(const drool_conf_file_t* conf_file) {
+    drool_assert(conf_file);
+    return conf_file->next;
+}
+
+int conf_file_set_next(drool_conf_file_t* conf_file, drool_conf_file_t* next) {
+    if (!conf_file) {
+        return CONF_EINVAL;
+    }
+    if (!next) {
+        return CONF_EINVAL;
+    }
+
+    conf_file->next = next;
+
+    return CONF_OK;
+}
+
+inline const char* conf_file_name(const drool_conf_file_t* conf_file) {
+    drool_assert(conf_file);
+    return conf_file->name;
+}
+
+int conf_file_set_name(drool_conf_file_t* conf_file, const char* name, size_t length) {
+    if (!conf_file) {
+        return CONF_EINVAL;
+    }
+    if (!name) {
+        return CONF_EINVAL;
+    }
+
+    if (conf_file->name) {
+        free(conf_file->name);
+    }
+    if (length) {
+        if (!(conf_file->name = strndup(name, length))) {
+            return CONF_ENOMEM;
+        }
+    }
+    else {
+        if (!(conf_file->name = strdup(name))) {
+            return CONF_ENOMEM;
+        }
+    }
+
+    return CONF_OK;
+}

--- a/src/conf_file.h
+++ b/src/conf_file.h
@@ -1,0 +1,58 @@
+/*
+ * DNS Reply Tool (drool)
+ *
+ * Copyright (c) 2017, OARC, Inc.
+ * Copyright (c) 2017, Comcast Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __drool_conf_file_h
+#define __drool_conf_file_h
+
+#include <stddef.h>
+
+#define CONF_FILE_T_INIT { 0, 0 }
+typedef struct drool_conf_file drool_conf_file_t;
+struct drool_conf_file {
+    drool_conf_file_t*  next;
+    char*               name;
+};
+
+drool_conf_file_t* conf_file_new(void);
+void conf_file_free(drool_conf_file_t* conf_file);
+void conf_file_release(drool_conf_file_t* conf_file);
+const drool_conf_file_t* conf_file_next(const drool_conf_file_t* conf_file);
+int conf_file_set_next(drool_conf_file_t* conf_file, drool_conf_file_t* next);
+const char* conf_file_name(const drool_conf_file_t* conf_file);
+int conf_file_set_name(drool_conf_file_t* conf_file, const char* name, size_t length);
+
+#endif /* __drool_conf_file_h */

--- a/src/conf_interface.c
+++ b/src/conf_interface.c
@@ -1,0 +1,113 @@
+/*
+ * DNS Reply Tool (drool)
+ *
+ * Copyright (c) 2017, OARC, Inc.
+ * Copyright (c) 2017, Comcast Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "conf.h"
+#include "drool.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+drool_conf_interface_t* conf_interface_new(void) {
+    drool_conf_interface_t* conf_interface = calloc(1, sizeof(drool_conf_interface_t));
+    return conf_interface;
+}
+
+void conf_interface_free(drool_conf_interface_t* conf_interface) {
+    if (conf_interface) {
+        conf_interface_release(conf_interface);
+        free(conf_interface);
+    }
+}
+
+void conf_interface_release(drool_conf_interface_t* conf_interface) {
+    if (conf_interface) {
+        if (conf_interface->name) {
+            free(conf_interface->name);
+            conf_interface->name = 0;
+        }
+    }
+}
+
+inline const drool_conf_interface_t* conf_interface_next(const drool_conf_interface_t* conf_interface) {
+    drool_assert(conf_interface);
+    return conf_interface->next;
+}
+
+int conf_interface_set_next(drool_conf_interface_t* conf_interface, drool_conf_interface_t* next) {
+    if (!conf_interface) {
+        return CONF_EINVAL;
+    }
+    if (!next) {
+        return CONF_EINVAL;
+    }
+
+    conf_interface->next = next;
+
+    return CONF_OK;
+}
+
+inline const char* conf_interface_name(const drool_conf_interface_t* conf_interface) {
+    drool_assert(conf_interface);
+    return conf_interface->name;
+}
+
+int conf_interface_set_name(drool_conf_interface_t* conf_interface, const char* name, size_t length) {
+    if (!conf_interface) {
+        return CONF_EINVAL;
+    }
+    if (!name) {
+        return CONF_EINVAL;
+    }
+
+    if (conf_interface->name) {
+        free(conf_interface->name);
+    }
+    if (length) {
+        if (!(conf_interface->name = strndup(name, length))) {
+            return CONF_ENOMEM;
+        }
+    }
+    else {
+        if (!(conf_interface->name = strdup(name))) {
+            return CONF_ENOMEM;
+        }
+    }
+
+    return CONF_OK;
+}

--- a/src/conf_interface.h
+++ b/src/conf_interface.h
@@ -1,0 +1,58 @@
+/*
+ * DNS Reply Tool (drool)
+ *
+ * Copyright (c) 2017, OARC, Inc.
+ * Copyright (c) 2017, Comcast Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __drool_conf_interface_h
+#define __drool_conf_interface_h
+
+#include <stddef.h>
+
+#define CONF_INTERFACE_T_INIT { 0, 0 }
+typedef struct drool_conf_interface drool_conf_interface_t;
+struct drool_conf_interface {
+    drool_conf_interface_t* next;
+    char*                   name;
+};
+
+drool_conf_interface_t* conf_interface_new(void);
+void conf_interface_free(drool_conf_interface_t* conf_interface);
+void conf_interface_release(drool_conf_interface_t* conf_interface);
+const drool_conf_interface_t* conf_interface_next(const drool_conf_interface_t* conf_interface);
+int conf_interface_set_next(drool_conf_interface_t* conf_interface, drool_conf_interface_t* next);
+const char* conf_interface_name(const drool_conf_interface_t* conf_interface);
+int conf_interface_set_name(drool_conf_interface_t* conf_interface, const char* name, size_t length);
+
+#endif /* __drool_conf_interface_h */


### PR DESCRIPTION
- Split conf structs and functions for file, interface and client_pool
  configuration to separate files
- Add client_pool option to skip waiting for any reply