### PR TITLE
TCP, send as, proper shutdown

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,6 +56,7 @@ drool_SOURCES = callback.c client.c client_pool.c \
     pcap-thread/pcap_thread.c \
     sllq/sllq.c
 dist_drool_SOURCES = assert.h callback.h client.h client_pool.h \
+    client_pool_sendas.h \
     conf.h conf_client_pool.h conf_file.h conf_interface.h \
     drool.h dropback.h log.h query.h stats_callback.h timing.h \
     omg-dns/omg_dns.h \

--- a/src/callback.c
+++ b/src/callback.c
@@ -225,7 +225,12 @@ static void do_timing(drool_t* context, const pcap_thread_packet_t* packet, cons
             if (sleep_to.tv_sec < now.tv_sec
                 || (sleep_to.tv_sec == now.tv_sec && sleep_to.tv_nsec < now.tv_nsec))
             {
-                log_print(conf_log(context->conf), LNETWORK, LWARNING, "Unable to keep up with timings");
+                log_printf(conf_log(context->conf), LNETWORK, LWARNING, "Unable to keep up with timings (process cost %lu.%09lu, packet diff %lu.%06lu, now %lu.%09lu, sleep to %lu.%09lu)",
+                    pdiff.tv_sec, pdiff.tv_nsec,
+                    diff.tv_sec, diff.tv_usec,
+                    now.tv_sec, now.tv_nsec,
+                    sleep_to.tv_sec, sleep_to.tv_nsec
+                );
             }
 
             if (sleep_to.tv_sec || sleep_to.tv_nsec) {

--- a/src/client.h
+++ b/src/client.h
@@ -53,6 +53,7 @@ enum drool_client_state {
     CLIENT_CONNECTED,
     CLIENT_SENDING,
     CLIENT_RECIVING,
+    CLIENT_CLOSING,
 
     CLIENT_SUCCESS,
     CLIENT_FAILED,
@@ -82,6 +83,7 @@ struct drool_client {
     drool_query_t*          query;
     ev_io                   write_watcher;
     ev_io                   read_watcher;
+    ev_io                   shutdown_watcher;
     drool_client_callback_t callback;
     drool_client_state_t    state;
     int                     errnum;
@@ -109,15 +111,13 @@ int client_is_dgram(const drool_client_t* client);
 int client_is_stream(const drool_client_t* client);
 int client_set_next(drool_client_t* client, drool_client_t* next);
 int client_set_prev(drool_client_t* client, drool_client_t* prev);
-int client_set_fd(drool_client_t* client, int fd);
 int client_set_start(drool_client_t* client, ev_tstamp start);
 int client_set_skip_reply(drool_client_t* client);
+drool_query_t* client_release_query(drool_client_t* client);
 
 int client_connect(drool_client_t* client, int ipproto, const struct sockaddr* addr, socklen_t addlen, struct ev_loop* loop);
-int client_connect_fd(drool_client_t* client, int fd, const struct sockaddr* addr, socklen_t addlen, struct ev_loop* loop);
 int client_send(drool_client_t* client, struct ev_loop* loop);
 int client_reuse(drool_client_t* client, drool_query_t* query);
-int client_abort(drool_client_t* client, struct ev_loop* loop);
-int client_close(drool_client_t* client);
+int client_close(drool_client_t* client, struct ev_loop* loop);
 
 #endif /* __drool_client_h */

--- a/src/client_pool.h
+++ b/src/client_pool.h
@@ -42,6 +42,7 @@
 #include "query.h"
 #include "conf.h"
 #include "client.h"
+#include "client_pool_sendas.h"
 
 #include <pthread.h>
 #include <ev.h>
@@ -57,13 +58,6 @@ enum drool_client_pool_state {
     CLIENT_POOL_ERROR
 };
 
-typedef enum drool_client_pool_sendas drool_client_pool_sendas_t;
-enum drool_client_pool_sendas {
-    CLIENT_POOL_SENDAS_ORIGINAL = 0,
-    CLIENT_POOL_SENDAS_UDP,
-    CLIENT_POOL_SENDAS_TCP
-};
-
 typedef struct drool_client_pool drool_client_pool_t;
 struct drool_client_pool {
     drool_client_pool_t* next;
@@ -77,11 +71,14 @@ struct drool_client_pool {
 
     struct ev_loop*             ev_loop;
     sllq_t                      queries;
+    drool_query_t*              query;
     ev_async                    notify_query;
     ev_async                    notify_stop;
     ev_timer                    timeout;
+    ev_timer                    retry;
 
-    drool_client_t*             client_list;
+    drool_client_t*             client_list_first;
+    drool_client_t*             client_list_last;
     size_t                      clients;
     size_t                      max_clients;
     ev_tstamp                   client_ttl;

--- a/src/client_pool_sendas.h
+++ b/src/client_pool_sendas.h
@@ -1,0 +1,48 @@
+/*
+ * DNS Reply Tool (drool)
+ *
+ * Copyright (c) 2017, OARC, Inc.
+ * Copyright (c) 2017, Comcast Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __drool_client_pool_sendas_h
+#define __drool_client_pool_sendas_h
+
+typedef enum drool_client_pool_sendas drool_client_pool_sendas_t;
+enum drool_client_pool_sendas {
+    CLIENT_POOL_SENDAS_ORIGINAL = 0,
+    CLIENT_POOL_SENDAS_UDP,
+    CLIENT_POOL_SENDAS_TCP
+};
+
+#endif /* __drool_client_pool_sendas_h */

--- a/src/conf.h
+++ b/src/conf.h
@@ -76,7 +76,7 @@ enum drool_conf_read_mode {
     LOG_T_INIT, \
     TIMING_MODE_KEEP, 0, 0, 0.0, \
     CONF_CLIENT_POOL_T_INIT, \
-    6 \
+    1 \
 }
 typedef struct drool_conf drool_conf_t;
 struct drool_conf {
@@ -112,7 +112,7 @@ struct drool_conf {
 
     drool_conf_client_pool_t    client_pool;
 
-    size_t                  context_client_pools; /* TODO */
+    size_t                  context_client_pools;
 };
 
 drool_conf_t* conf_new(void);
@@ -141,6 +141,7 @@ drool_timing_mode_t conf_timing_mode(const drool_conf_t* conf);
 unsigned long int conf_timing_increase(const drool_conf_t* conf);
 unsigned long int conf_timing_reduce(const drool_conf_t* conf);
 long double conf_timing_multiply(const drool_conf_t* conf);
+size_t conf_context_client_pools(const drool_conf_t* conf);
 int conf_add_read(drool_conf_t* conf, const char* file, size_t length);
 int conf_add_input(drool_conf_t* conf, const char* interface, size_t length);
 int conf_set_read_mode(drool_conf_t* conf, drool_conf_read_mode_t read_mode);
@@ -149,6 +150,7 @@ int conf_set_read_iter(drool_conf_t* conf, size_t read_iter);
 int conf_set_write(drool_conf_t* conf, const char* file, size_t length);
 int conf_set_output(drool_conf_t* conf, const char* interface, size_t length);
 */
+int conf_set_context_client_pools(drool_conf_t* conf, size_t context_client_pools);
 const drool_log_t* conf_log(const drool_conf_t* conf);
 drool_log_t* conf_log_rw(drool_conf_t* conf);
 const drool_conf_client_pool_t* conf_client_pool(const drool_conf_t* conf);

--- a/src/conf_client_pool.c
+++ b/src/conf_client_pool.c
@@ -79,6 +79,11 @@ inline int conf_client_pool_have_max_reuse_clients(const drool_conf_client_pool_
     return conf_client_pool->have_max_reuse_clients;
 }
 
+inline int conf_client_pool_have_sendas(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->have_sendas;
+}
+
 inline const drool_conf_client_pool_t* conf_client_pool_next(const drool_conf_client_pool_t* conf_client_pool) {
     drool_assert(conf_client_pool);
     return conf_client_pool->next;
@@ -112,6 +117,11 @@ inline int conf_client_pool_skip_reply(const drool_conf_client_pool_t* conf_clie
 inline size_t conf_client_pool_max_reuse_clients(const drool_conf_client_pool_t* conf_client_pool) {
     drool_assert(conf_client_pool);
     return conf_client_pool->max_reuse_clients;
+}
+
+inline drool_client_pool_sendas_t conf_client_pool_sendas(const drool_conf_client_pool_t* conf_client_pool) {
+    drool_assert(conf_client_pool);
+    return conf_client_pool->sendas;
 }
 
 int conf_client_pool_set_next(drool_conf_client_pool_t* conf_client_pool, drool_conf_client_pool_t* next) {
@@ -199,6 +209,17 @@ int conf_client_pool_set_max_reuse_clients(drool_conf_client_pool_t* conf_client
 
     conf_client_pool->max_reuse_clients = max_reuse_clients;
     conf_client_pool->have_max_reuse_clients = 1;
+
+    return CONF_OK;
+}
+
+int conf_client_pool_set_sendas(drool_conf_client_pool_t* conf_client_pool, drool_client_pool_sendas_t sendas) {
+    if (!conf_client_pool) {
+        return CONF_EINVAL;
+    }
+
+    conf_client_pool->sendas = sendas;
+    conf_client_pool->have_sendas = 1;
 
     return CONF_OK;
 }

--- a/src/conf_client_pool.h
+++ b/src/conf_client_pool.h
@@ -38,12 +38,15 @@
 #ifndef __drool_conf_client_pool_h
 #define __drool_conf_client_pool_h
 
+#include "client_pool_sendas.h"
+
 #include <stddef.h>
 
 #define CONF_CLIENT_POOL_T_INIT { \
     0, \
     0, 0, 0, 0, \
-    0, 0, 0, 0 \
+    0, 0, 0, 0, \
+    CLIENT_POOL_SENDAS_ORIGINAL \
 }
 typedef struct drool_conf_client_pool drool_conf_client_pool_t;
 struct drool_conf_client_pool {
@@ -54,12 +57,15 @@ struct drool_conf_client_pool {
     unsigned short  have_client_ttl : 1;
     unsigned short  skip_reply : 1;
     unsigned short  have_max_reuse_clients : 1;
+    unsigned short  have_sendas : 1;
 
     char*           target_host;
     char*           target_service;
     size_t          max_clients;
     double          client_ttl;
     size_t          max_reuse_clients;
+
+    drool_client_pool_sendas_t  sendas;
 };
 
 drool_conf_client_pool_t* conf_client_pool_new(void);
@@ -68,6 +74,7 @@ int conf_client_pool_have_target(const drool_conf_client_pool_t* conf_client_poo
 int conf_client_pool_have_max_clients(const drool_conf_client_pool_t* conf_client_pool);
 int conf_client_pool_have_client_ttl(const drool_conf_client_pool_t* conf_client_pool);
 int conf_client_pool_have_max_reuse_clients(const drool_conf_client_pool_t* conf_client_pool);
+int conf_client_pool_have_sendas(const drool_conf_client_pool_t* conf_client_pool);
 const drool_conf_client_pool_t* conf_client_pool_next(const drool_conf_client_pool_t* conf_client_pool);
 const char* conf_client_pool_target_host(const drool_conf_client_pool_t* conf_client_pool);
 const char* conf_client_pool_target_service(const drool_conf_client_pool_t* conf_client_pool);
@@ -75,11 +82,13 @@ size_t conf_client_pool_max_clients(const drool_conf_client_pool_t* conf_client_
 double conf_client_pool_client_ttl(const drool_conf_client_pool_t* conf_client_pool);
 int conf_client_pool_skip_reply(const drool_conf_client_pool_t* conf_client_pool);
 size_t conf_client_pool_max_reuse_clients(const drool_conf_client_pool_t* conf_client_pool);
+drool_client_pool_sendas_t conf_client_pool_sendas(const drool_conf_client_pool_t* conf_client_pool);
 int conf_client_pool_set_next(drool_conf_client_pool_t* conf_client_pool, drool_conf_client_pool_t* next);
 int conf_client_pool_set_target(drool_conf_client_pool_t* conf_client_pool, const char* host, size_t host_length, const char* service, size_t service_length);
 int conf_client_pool_set_max_clients(drool_conf_client_pool_t* conf_client_pool, size_t max_clients);
 int conf_client_pool_set_client_ttl(drool_conf_client_pool_t* conf_client_pool, double client_ttl);
 int conf_client_pool_set_skip_reply(drool_conf_client_pool_t* conf_client_pool);
 int conf_client_pool_set_max_reuse_clients(drool_conf_client_pool_t* conf_client_pool, size_t max_reuse_clients);
+int conf_client_pool_set_sendas(drool_conf_client_pool_t* conf_client_pool, drool_client_pool_sendas_t sendas);
 
 #endif /* __drool_conf_client_pool_h */

--- a/src/drool.conf.5.in
+++ b/src/drool.conf.5.in
@@ -69,6 +69,9 @@ todo
 \fBtiming\fR multiply MULTIPLY_AS_FLOAT ;
 todo
 .TP
+\fBcontext\fR client_pools NUMBER ;
+todo
+.TP
 \fBclient_pool\fR target " IP_OR_HOSTNAME " " SERVICE_OR_PORT ";
 todo
 .TP
@@ -79,6 +82,12 @@ todo
 todo
 .TP
 \fBclient_pool\fR skip_reply ;
+todo
+.TP
+\fBclient_pool\fR max_reuse_clients NUMBER ;
+todo
+.TP
+\fBclient_pool\fR sendas < original | udp | tcp > ;
 todo
 .TP
 \fBwrite\fR " FILE " ;

--- a/src/drool.conf.example
+++ b/src/drool.conf.example
@@ -9,10 +9,14 @@ timing ignore;
 #timing reduce 200;
 #timing multiply 1.5;
 
+#context client_pools 1;
+
 client_pool target "127.0.0.1" "53";
-client_pool max_clients 5000;
+client_pool max_clients 100;
 client_pool client_ttl 0.05;
 #client_pool skip_reply;
+#client_pool max_reuse_clients 20;
+#client_pool sendas tcp;
 
 # Not working yet:
 #write "/path/to/file.pcap";

--- a/src/log.c
+++ b/src/log.c
@@ -43,7 +43,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 #include <pthread.h>
 
 static const drool_log_settings_t* get_facility(const drool_log_t* log, const drool_log_facility_t facility) {
@@ -268,10 +267,9 @@ void log_printf_fileline(const drool_log_t* log, const drool_log_facility_t faci
     fflush(stdout);
 }
 
-void log_errnof_fileline(const drool_log_t* log, const drool_log_facility_t facility, const drool_log_level_t level, const char* file, size_t line, const char* format, ...) {
+void log_errnumf_fileline(const drool_log_t* log, const drool_log_facility_t facility, const drool_log_level_t level, const char* file, size_t line, int errnum, const char* format, ...) {
     va_list ap;
     char buf[512];
-    int errnum = errno;
 
     drool_assert(log);
     if (!log) {

--- a/src/log.h
+++ b/src/log.h
@@ -39,6 +39,7 @@
 #define __drool_log_h
 
 #include <stddef.h>
+#include <errno.h>
 
 #define LOG_SETTINGS_T_INIT         { 0, 0, 0, 1, 1, 1 }
 #define LOG_SETTINGS_T_INIT_NONE    { 0, 0, 0, 0, 0, 0 }
@@ -121,10 +122,15 @@ void log_printf_fileline(const drool_log_t* log, const drool_log_facility_t faci
 #define log_printf(log, facility, level, format, args...) \
     log_printf_fileline(log, facility, level, __FILE__, __LINE__, format, args)
 
-void log_errnof_fileline(const drool_log_t* log, const drool_log_facility_t facility, const drool_log_level_t level, const char* file, size_t line, const char* format, ...);
+void log_errnumf_fileline(const drool_log_t* log, const drool_log_facility_t facility, const drool_log_level_t level, const char* file, size_t line, int errnum, const char* format, ...);
+#define log_errnum(log, facility, level, errnum, text) \
+    log_errnumf_fileline(log, facility, level, __FILE__, __LINE__, errnum, text)
+#define log_errnumf(log, facility, level, errnum, format, args...) \
+    log_errnumf_fileline(log, facility, level, __FILE__, __LINE__, errnum, format, args)
+
 #define log_errno(log, facility, level, text) \
-    log_errnof_fileline(log, facility, level, __FILE__, __LINE__, text)
+    log_errnumf_fileline(log, facility, level, __FILE__, __LINE__, errno, text)
 #define log_errnof(log, facility, level, format, args...) \
-    log_errnof_fileline(log, facility, level, __FILE__, __LINE__, format, args)
+    log_errnumf_fileline(log, facility, level, __FILE__, __LINE__, errno, format, args)
 
 #endif /* __drool_log_h */


### PR DESCRIPTION
- Fix #7: Verified TCP support, can easily break 50k conn/sec but due to
  socket exhaustion in the OS/kernel it can not be sustained
- Add `client_pool sendas <val>` to control how queries are sent
- Add timing details to warning about not keeping up with timings
- Do proper `shutdown()` of the socket
- Reworked client about/close/free
- When failing to allocate socket due to exhaustion, retry the query
  until successful
- Use inline helpers for client_pool lists
- Rework log functions to be able to use given errno
- Remove `client_set_fd()`, `client_connect_fd()` and `client_abort()`
- Add config option `context client_pools <num>;` to control the number
  of client pools running, set default to 1
- Update man-page