### PR TITLE
Log format

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -41,6 +41,19 @@
 #include <stddef.h>
 #include <errno.h>
 
+#ifndef LOG_DATETIME
+#define LOG_DATETIME 1
+#endif
+#ifndef LOG_FILENAME_LINE
+#define LOG_FILENAME_LINE 1
+#endif
+#ifndef LOG_SHORT_FILENAME
+#define LOG_SHORT_FILENAME 1
+#endif
+#ifndef LOG_THREAD_ID
+#define LOG_THREAD_ID 0
+#endif
+
 #define LOG_SETTINGS_T_INIT         { 0, 0, 0, 1, 1, 1 }
 #define LOG_SETTINGS_T_INIT_NONE    { 0, 0, 0, 0, 0, 0 }
 #define LOG_SETTINGS_T_INIT_ALL     { 1, 1, 1, 1, 1, 1 }


### PR DESCRIPTION
- Cleaned up log format
- Use a buffer to create the log line before output to solve multiple threads
  writing in each others log lines
- Add compile options (defines) for controling format
  - `LOG_DATETIME` if set, adds a simple date and time at the start
  - `LOG_FILENAME_LINE` if set, logs filename and line
  - `LOG_SHORT_FILENAME` if set, only show filename.ext
  - `LOG_THREAD_ID` if set, adds `pthread_self()`