### PR TITLE
Fix #74: Best effort timing mode, fix usage of `nanosleep()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,51 @@ efficacy of subsequent bug fixes.
 
 ## Usage example
 
-This example reads all DNS queries from a PCAP file, sends them to
-a nameserver at `127.0.0.1` and ignores both timings and replies.
+Send all DNS queries twice as fast as found in the PCAP file to localhost
+using UDP:
 
-```
-drool \
-  -vv \
-  -c 'text:timing ignore;' \
-  -c 'text:client_pool target "127.0.0.1" "53";' \
-  -c 'text:client_pool skip_reply;' \
+```shell
+drool -vv \
+  -c 'text:timing multiply 2.0; client_pool target "127.0.0.1" "53"; client_pool sendas udp;' \
   -r file.pcap
 ```
+
+Only look for DNS queries in TCP traffic and send it to localhost:
+
+```shell
+drool -vv \
+  -c 'text:filter "tcp"; client_pool target "127.0.0.1" "53";' \
+  -r file.pcap
+```
+
+Listen for DNS queries on eth0 and send them to an (assuming) internal server:
+
+```shell
+drool -vv \
+  -c 'text:filter "port 53"; client_pool target "172.16.1.2" "53";' \
+  -i eth0
+```
+
+Take all UDP DNS queries found in the PCAP file and send them as fast as
+possible to localhost by ignoring both timings, replies and starting 5
+contexts (threads) that will simultaneously send queries:
+
+```shell
+drool -vv \
+  -c 'text:filter "udp"; timing ignore; context client_pools 5; client_pool target "127.0.0.1" "53"; client_pool skip_reply;' \
+  -r file.pcap
+```
+
+## Timing warnings
+
+The warnings from timing mode `keep` consists of:
+- `process cost`: This is the CPU cost of processing the packet including the cost of measuring the cost
+- `packet diff`: This is the timing differential between the previous packet and the packet being processed as seen from the PCAP, i.e. the time to wait before sending it
+- `now`: Is the time "now" or at least when the processing for this packet begun
+- `sleep to`: Was the time it should have slept to
+
+The values for `now` and `sleep to` are in monotonic or real-time clock
+depending on the available system functionality during compilation.
 
 ## Dependencies and build tools
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -553,6 +553,29 @@ static int parse_timing_multiply(void* user, const parseconf_token_t* tokens, co
     return 0;
 }
 
+static parseconf_token_type_t timing_best_effort_tokens[] = {
+    PARSECONF_TOKEN_END
+};
+
+static int parse_timing_best_effort(void* user, const parseconf_token_t* tokens, const char** errstr)
+{
+    drool_conf_t* conf = (drool_conf_t*)user;
+
+    if (!conf) {
+        return 1;
+    }
+    if (!tokens) {
+        return 1;
+    }
+    if (!errstr) {
+        return 1;
+    }
+
+    conf->timing_mode = TIMING_MODE_BEST_EFFORT;
+
+    return 0;
+}
+
 static parseconf_syntax_t timing_syntax[] = {
     /* timing ignore; */
     { "ignore", parse_timing_ignore, timing_ignore_tokens, 0 },
@@ -564,6 +587,8 @@ static parseconf_syntax_t timing_syntax[] = {
     { "reduce", parse_timing_reduce, timing_reduce_tokens, 0 },
     /* timing multiply <multiplication>; */
     { "multiply", parse_timing_multiply, timing_multiply_tokens, 0 },
+    /* timing best_effort; */
+    { "best_effort", parse_timing_best_effort, timing_best_effort_tokens, 0 },
     PARSECONF_SYNTAX_END
 };
 

--- a/src/drool.conf.5.in
+++ b/src/drool.conf.5.in
@@ -98,6 +98,12 @@ received, will give a warning if it can't keep up sending it out at the
 same rate.
 This is the default timing mode if none is specified.
 .TP
+\fBtiming\fR best_effort ;
+Set the timing mode to try and keep up with interval between the traffic
+received.
+Unlike \fBkeep\fR, this mode will not warn about being unable to keep to
+the timings.
+.TP
 \fBtiming\fR add NANOSECONDS ;
 Set the timing mode to add the given nanoseconds to the interval between
 the traffic received.

--- a/src/timing.h
+++ b/src/timing.h
@@ -44,7 +44,8 @@ enum drool_timing_mode {
     TIMING_MODE_IGNORE,
     TIMING_MODE_INCREASE,
     TIMING_MODE_REDUCE,
-    TIMING_MODE_MULTIPLY
+    TIMING_MODE_MULTIPLY,
+    TIMING_MODE_BEST_EFFORT
 };
 
 #endif /* __drool_timing_h */


### PR DESCRIPTION
- Add `best_effort` timing mode
- `nanosleep()` is not absolute, need relative value from `now` and `last_time` (this is not optimal #75)
- Update README usage from man-page
- Add timing warning explanation to README