### PR TITLE
WIP: timing rework

### DIFF
--- a/src/callback.c
+++ b/src/callback.c
@@ -45,6 +45,8 @@
 #include "client_pool.h"
 #include "assert.h"
 
+#define N1e9 1000000000
+
 static void queue_dns(drool_t* context, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
 {
     omg_dns_t                   dns = OMG_DNS_T_INIT;
@@ -101,8 +103,9 @@ static void queue_dns(drool_t* context, const pcap_thread_packet_t* packet, cons
     context->packets_size += length;
 }
 
-static void do_timing(drool_t* context, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
+void timing_init(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
 {
+    drool_t*                    context = (drool_t*)user;
     const pcap_thread_packet_t* walkpkt;
 
     for (walkpkt = packet; walkpkt; walkpkt = walkpkt->prevpkt) {
@@ -110,43 +113,395 @@ static void do_timing(drool_t* context, const pcap_thread_packet_t* packet, cons
             break;
         }
     }
-    if (walkpkt) {
-	struct timespec mono_now;
-	if (clock_gettime(CLOCK_MONOTONIC, &mono_now)) {
-		drool_assert("unable to sync clocks" == NULL);
-	}
-
-	/* init */
-	if (!context->mono_diff.tv_sec && !context->mono_diff.tv_nsec) {
-		context->mono_diff.tv_sec = mono_now.tv_sec - walkpkt->pkthdr.ts.tv_sec;
-		context->mono_diff.tv_nsec = mono_now.tv_nsec - walkpkt->pkthdr.ts.tv_usec * 1000;
-	}
-
-	struct timespec sleep_to;
-	sleep_to.tv_sec = context->mono_diff.tv_sec + walkpkt->pkthdr.ts.tv_sec;
-	sleep_to.tv_nsec = context->mono_diff.tv_nsec + walkpkt->pkthdr.ts.tv_usec * 1000;
-	if (sleep_to.tv_nsec > 1e9) {
-		sleep_to.tv_sec += 1;
-		sleep_to.tv_nsec -= 1e9;
-	} else if (sleep_to.tv_nsec < 0) {
-		sleep_to.tv_sec -= 1;
-		sleep_to.tv_nsec += 1e9;
-	}
-	drool_assert(sleep_to.tv_sec > 0);
-	drool_assert(sleep_to.tv_nsec > 0);
-	drool_assert(sleep_to.tv_nsec < 1e9);
-	if (sleep_to.tv_sec - mono_now.tv_sec < 0 || ((sleep_to.tv_sec == mono_now.tv_sec) && sleep_to.tv_nsec - mono_now.tv_nsec < -1e6)) {
-		printf("VELKY SPATNY, lag %ld sec %ld nsec\n", sleep_to.tv_sec - mono_now.tv_sec, sleep_to.tv_nsec - mono_now.tv_nsec);
-	} else {
-		int ret;
-		while ((ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &sleep_to, 0)) == EINTR);
-	}
-
-        // log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "pkthdr.ts %lu.%06lu", walkpkt->pkthdr.ts.tv_sec, walkpkt->pkthdr.ts.tv_usec);
-        // log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "last_packet %lu.%06lu", context->last_packet.tv_sec, context->last_packet.tv_usec);
-
-
+    if (!walkpkt) {
+        return;
     }
+
+#if HAVE_CLOCK_NANOSLEEP
+    if (clock_gettime(CLOCK_MONOTONIC, &context->last_ts)) {
+        log_errno(conf_log(context->conf), LNETWORK, LDEBUG, "clock_gettime()");
+        return;
+    }
+    context->diff = context->last_ts;
+    context->diff.tv_sec -= walkpkt->pkthdr.ts.tv_sec;
+    context->diff.tv_nsec -= walkpkt->pkthdr.ts.tv_usec * 1000;
+    log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_init() with clock_nanosleep() now is %ld.%ld, diff of first pkt %ld.%ld",
+        context->last_ts.tv_sec, context->last_ts.tv_nsec,
+        context->diff.tv_sec, context->diff.tv_nsec);
+#elif HAVE_NANOSLEEP
+    log_print(conf_log(context->conf), LNETWORK, LDEBUG, "timing_init() with nanosleep()");
+#else
+#error "No clock_nanosleep() or nanosleep(), can not continue"
+#endif
+
+    context->last_pkthdr_ts = walkpkt->pkthdr.ts;
+
+    switch (conf_timing_mode(context->conf)) {
+    case TIMING_MODE_KEEP:
+    case TIMING_MODE_BEST_EFFORT:
+        log_print(conf_log(context->conf), LNETWORK, LDEBUG, "timing_init() mode keep");
+        context->timing_callback = timing_keep;
+        break;
+    case TIMING_MODE_INCREASE:
+        context->timing_callback = timing_increase;
+        context->mod_ts.tv_sec   = conf_timing_increase(context->conf) / N1e9;
+        context->mod_ts.tv_nsec  = conf_timing_increase(context->conf) % N1e9;
+        log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_init() mode increase by %ld.%ld", context->mod_ts.tv_sec, context->mod_ts.tv_nsec);
+        break;
+    case TIMING_MODE_REDUCE:
+        context->timing_callback = timing_reduce;
+        context->mod_ts.tv_sec   = conf_timing_reduce(context->conf) / N1e9;
+        context->mod_ts.tv_nsec  = conf_timing_reduce(context->conf) % N1e9;
+        log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_init() mode reduce by %ld.%ld", context->mod_ts.tv_sec, context->mod_ts.tv_nsec);
+        break;
+    case TIMING_MODE_MULTIPLY:
+        context->timing_callback = timing_multiply;
+        log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_init() mode multiply by %f", conf_timing_multiply(context->conf));
+        break;
+    default:
+        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "invalid timing mode %d", conf_timing_mode(context->conf));
+        return;
+    }
+
+    queue_dns(context, packet, payload, length);
+}
+
+void timing_keep(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
+{
+    drool_t*                    context = (drool_t*)user;
+    const pcap_thread_packet_t* walkpkt;
+
+    for (walkpkt = packet; walkpkt; walkpkt = walkpkt->prevpkt) {
+        if (walkpkt->have_pkthdr) {
+            break;
+        }
+    }
+    if (!walkpkt) {
+        return;
+    }
+
+#if HAVE_CLOCK_NANOSLEEP
+    {
+        struct timespec to = {
+            context->diff.tv_sec + walkpkt->pkthdr.ts.tv_sec,
+            context->diff.tv_nsec + (walkpkt->pkthdr.ts.tv_usec * 1000)
+        };
+        int ret = EINTR;
+
+        if (to.tv_nsec >= N1e9) {
+            to.tv_sec += 1;
+            to.tv_nsec -= N1e9;
+        } else if (to.tv_nsec < 0) {
+            to.tv_sec -= 1;
+            to.tv_nsec += N1e9;
+        }
+
+        while (ret) {
+            log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_keep() sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+            ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+            if (ret && ret != EINTR) {
+                log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
+                return;
+            }
+        }
+    }
+#elif HAVE_NANOSLEEP
+    {
+        struct timespec diff = {
+            walkpkt->pkthdr.ts.tv_sec - context->last_pkthdr_ts.tv_sec,
+            (walkpkt->pkthdr.ts.tv_usec - context->last_pkthdr_ts.tv_usec) * 1000
+        };
+        int ret = EINTR;
+
+        if (diff.tv_nsec >= N1e9) {
+            diff.tv_sec += 1;
+            diff.tv_nsec -= N1e9;
+        } else if (diff.tv_nsec < 0) {
+            diff.tv_sec -= 1;
+            diff.tv_nsec += N1e9;
+        }
+
+        if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+            while (ret) {
+                log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_keep() sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+                if ((ret = nanosleep(&diff, &diff))) {
+                    ret = errno;
+                    if (ret != EINTR) {
+                        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                        return;
+                    }
+                }
+            }
+        }
+
+        context->last_pkthdr_ts = walkpkt->pkthdr.ts;
+    }
+#endif
+
+    queue_dns(context, packet, payload, length);
+}
+
+void timing_increase(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
+{
+    drool_t*                    context = (drool_t*)user;
+    const pcap_thread_packet_t* walkpkt;
+
+    for (walkpkt = packet; walkpkt; walkpkt = walkpkt->prevpkt) {
+        if (walkpkt->have_pkthdr) {
+            break;
+        }
+    }
+    if (!walkpkt) {
+        return;
+    }
+
+    {
+        struct timespec diff = {
+            walkpkt->pkthdr.ts.tv_sec - context->last_pkthdr_ts.tv_sec,
+            (walkpkt->pkthdr.ts.tv_usec - context->last_pkthdr_ts.tv_usec) * 1000
+        };
+        int ret = EINTR;
+
+        if (diff.tv_nsec >= N1e9) {
+            diff.tv_sec += 1;
+            diff.tv_nsec -= N1e9;
+        } else if (diff.tv_nsec < 0) {
+            diff.tv_sec -= 1;
+            diff.tv_nsec += N1e9;
+        }
+
+        diff.tv_sec += context->mod_ts.tv_sec;
+        diff.tv_nsec += context->mod_ts.tv_nsec;
+        if (diff.tv_nsec >= N1e9) {
+            diff.tv_sec += 1;
+            diff.tv_nsec -= N1e9;
+        }
+
+        if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+#if HAVE_CLOCK_NANOSLEEP
+            {
+                struct timespec to = {
+                    context->last_ts.tv_sec + diff.tv_sec,
+                    context->last_ts.tv_nsec + diff.tv_nsec
+                };
+
+                if (to.tv_nsec >= N1e9) {
+                    to.tv_sec += 1;
+                    to.tv_nsec -= N1e9;
+                } else if (to.tv_nsec < 0) {
+                    to.tv_sec -= 1;
+                    to.tv_nsec += N1e9;
+                }
+
+                while (ret) {
+                    log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_increase() sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+                    ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+                    if (ret && ret != EINTR) {
+                        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
+                        return;
+                    }
+                }
+            }
+#elif HAVE_NANOSLEEP
+            while (ret) {
+                log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_increase() sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+                if ((ret = nanosleep(&diff, &diff))) {
+                    ret = errno;
+                    if (ret != EINTR) {
+                        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                        return;
+                    }
+                }
+            }
+#endif
+        }
+
+        context->last_pkthdr_ts = walkpkt->pkthdr.ts;
+    }
+
+#if HAVE_CLOCK_NANOSLEEP
+    if (clock_gettime(CLOCK_MONOTONIC, &context->last_ts)) {
+        log_errno(conf_log(context->conf), LNETWORK, LDEBUG, "clock_gettime()");
+        return;
+    }
+#endif
+
+    queue_dns(context, packet, payload, length);
+}
+
+void timing_reduce(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
+{
+    drool_t*                    context = (drool_t*)user;
+    const pcap_thread_packet_t* walkpkt;
+
+    for (walkpkt = packet; walkpkt; walkpkt = walkpkt->prevpkt) {
+        if (walkpkt->have_pkthdr) {
+            break;
+        }
+    }
+    if (!walkpkt) {
+        return;
+    }
+
+    {
+        struct timespec diff = {
+            walkpkt->pkthdr.ts.tv_sec - context->last_pkthdr_ts.tv_sec,
+            (walkpkt->pkthdr.ts.tv_usec - context->last_pkthdr_ts.tv_usec) * 1000
+        };
+        int ret = EINTR;
+
+        if (diff.tv_nsec >= N1e9) {
+            diff.tv_sec += 1;
+            diff.tv_nsec -= N1e9;
+        } else if (diff.tv_nsec < 0) {
+            diff.tv_sec -= 1;
+            diff.tv_nsec += N1e9;
+        }
+
+        diff.tv_sec -= context->mod_ts.tv_sec;
+        diff.tv_nsec -= context->mod_ts.tv_nsec;
+        if (diff.tv_nsec < 0) {
+            diff.tv_sec -= 1;
+            diff.tv_nsec += N1e9;
+        }
+
+        if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+#if HAVE_CLOCK_NANOSLEEP
+            {
+                struct timespec to = {
+                    context->last_ts.tv_sec + diff.tv_sec,
+                    context->last_ts.tv_nsec + diff.tv_nsec
+                };
+
+                if (to.tv_nsec >= N1e9) {
+                    to.tv_sec += 1;
+                    to.tv_nsec -= N1e9;
+                } else if (to.tv_nsec < 0) {
+                    to.tv_sec -= 1;
+                    to.tv_nsec += N1e9;
+                }
+
+                while (ret) {
+                    log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_reduce() sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+                    ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+                    if (ret && ret != EINTR) {
+                        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
+                        return;
+                    }
+                }
+            }
+#elif HAVE_NANOSLEEP
+            while (ret) {
+                log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_reduce() sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+                if ((ret = nanosleep(&diff, &diff))) {
+                    ret = errno;
+                    if (ret != EINTR) {
+                        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                        return;
+                    }
+                }
+            }
+#endif
+        }
+
+        context->last_pkthdr_ts = walkpkt->pkthdr.ts;
+    }
+
+#if HAVE_CLOCK_NANOSLEEP
+    if (clock_gettime(CLOCK_MONOTONIC, &context->last_ts)) {
+        log_errno(conf_log(context->conf), LNETWORK, LDEBUG, "clock_gettime()");
+        return;
+    }
+#endif
+
+    queue_dns(context, packet, payload, length);
+}
+
+void timing_multiply(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
+{
+    drool_t*                    context = (drool_t*)user;
+    const pcap_thread_packet_t* walkpkt;
+
+    for (walkpkt = packet; walkpkt; walkpkt = walkpkt->prevpkt) {
+        if (walkpkt->have_pkthdr) {
+            break;
+        }
+    }
+    if (!walkpkt) {
+        return;
+    }
+
+    {
+        struct timespec diff = {
+            walkpkt->pkthdr.ts.tv_sec - context->last_pkthdr_ts.tv_sec,
+            (walkpkt->pkthdr.ts.tv_usec - context->last_pkthdr_ts.tv_usec) * 1000
+        };
+        int ret = EINTR;
+
+        if (diff.tv_nsec >= N1e9) {
+            diff.tv_sec += 1;
+            diff.tv_nsec -= N1e9;
+        } else if (diff.tv_nsec < 0) {
+            diff.tv_sec -= 1;
+            diff.tv_nsec += N1e9;
+        }
+
+        diff.tv_sec  = (time_t)((float)diff.tv_sec * conf_timing_multiply(context->conf));
+        diff.tv_nsec = (long)((float)diff.tv_nsec * conf_timing_multiply(context->conf));
+
+        if (diff.tv_sec > -1 && diff.tv_nsec > -1) {
+            if (diff.tv_nsec >= N1e9) {
+                diff.tv_sec += diff.tv_nsec / N1e9;
+                diff.tv_nsec %= N1e9;
+            }
+
+#if HAVE_CLOCK_NANOSLEEP
+            {
+                struct timespec to = {
+                    context->last_ts.tv_sec + diff.tv_sec,
+                    context->last_ts.tv_nsec + diff.tv_nsec
+                };
+
+                if (to.tv_nsec >= N1e9) {
+                    to.tv_sec += 1;
+                    to.tv_nsec -= N1e9;
+                } else if (to.tv_nsec < 0) {
+                    to.tv_sec -= 1;
+                    to.tv_nsec += N1e9;
+                }
+
+                while (ret) {
+                    log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_multiply() sleep to %ld.%ld", to.tv_sec, to.tv_nsec);
+                    ret = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &to, 0);
+                    if (ret && ret != EINTR) {
+                        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "clock_nanosleep(%ld.%ld) %d", to.tv_sec, to.tv_nsec, ret);
+                        return;
+                    }
+                }
+            }
+#elif HAVE_NANOSLEEP
+            while (ret) {
+                log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "timing_multiply() sleep for %ld.%ld", diff.tv_sec, diff.tv_nsec);
+                if ((ret = nanosleep(&diff, &diff))) {
+                    ret = errno;
+                    if (ret != EINTR) {
+                        log_errnof(conf_log(context->conf), LNETWORK, LDEBUG, "nanosleep(%ld.%ld) %d", diff.tv_sec, diff.tv_nsec, ret);
+                        return;
+                    }
+                }
+            }
+#endif
+        }
+
+        context->last_pkthdr_ts = walkpkt->pkthdr.ts;
+    }
+
+#if HAVE_CLOCK_NANOSLEEP
+    if (clock_gettime(CLOCK_MONOTONIC, &context->last_ts)) {
+        log_errno(conf_log(context->conf), LNETWORK, LDEBUG, "clock_gettime()");
+        return;
+    }
+#endif
 
     queue_dns(context, packet, payload, length);
 }
@@ -167,7 +522,7 @@ void callback_udp(u_char* user, const pcap_thread_packet_t* packet, const u_char
         queue_dns(context, packet, payload, length);
         return;
     }
-    do_timing(context, packet, payload, length);
+    context->timing_callback(user, packet, payload, length);
 }
 
 void callback_tcp(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length)
@@ -193,20 +548,5 @@ void callback_tcp(u_char* user, const pcap_thread_packet_t* packet, const u_char
         queue_dns(context, packet, payload, length);
         return;
     }
-    do_timing(context, packet, payload, length);
+    context->timing_callback(user, packet, payload, length);
 }
-
-/*
-void callback(u_char* user, const struct pcap_pkthdr* pkthdr, const u_char* pkt, const char* name, int dlt) {
-    drool_t* context = (drool_t*)user;
-
-    drool_assert(context);
-    drool_assert(pkthdr);
-    drool_assert(pkt);
-    drool_assert(name);
-
-    log_printf(conf_log(context->conf), LNETWORK, LDEBUG, "packet received from %s", name);
-
-    context->packets_seen++;
-}
-*/

--- a/src/callback.h
+++ b/src/callback.h
@@ -43,4 +43,10 @@
 void callback_udp(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
 void callback_tcp(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
 
+void timing_init(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
+void timing_keep(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
+void timing_increase(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
+void timing_reduce(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
+void timing_multiply(u_char* user, const pcap_thread_packet_t* packet, const u_char* payload, size_t length);
+
 #endif /* __drool_callback_h */

--- a/src/conf.c
+++ b/src/conf.c
@@ -571,6 +571,8 @@ static int parse_timing_best_effort(void* user, const parseconf_token_t* tokens,
         return 1;
     }
 
+    log_print(conf_log(conf), LCORE, LWARNING, "best_effort mode is deprecated, keep will be used");
+
     conf->timing_mode = TIMING_MODE_BEST_EFFORT;
 
     return 0;

--- a/src/drool.c
+++ b/src/drool.c
@@ -150,7 +150,8 @@ static int run(drool_conf_t* conf, pcap_thread_t* pcap_thread)
                 exit(DROOL_ENOMEM);
             }
 
-            context->conf = conf;
+            context->timing_callback = timing_init;
+            context->conf            = conf;
             for (n = 0; n < conf->context_client_pools; n++) { /* TODO */
                 if (!(context->client_pool = client_pool_new(conf))) {
                     log_print(conf_log(conf), LCORE, LCRITICAL, "Unable to allocate client_pool with client_pool_new()");
@@ -188,7 +189,8 @@ static int run(drool_conf_t* conf, pcap_thread_t* pcap_thread)
                 exit(DROOL_ENOMEM);
             }
 
-            context->conf = conf;
+            context->timing_callback = timing_init;
+            context->conf            = conf;
             for (n = 0; n < conf->context_client_pools; n++) { /* TODO */
                 if (!(context->client_pool = client_pool_new(conf))) {
                     log_print(conf_log(conf), LCORE, LCRITICAL, "Unable to allocate client_pool with client_pool_new()");

--- a/src/drool.conf.5.in
+++ b/src/drool.conf.5.in
@@ -99,10 +99,9 @@ same rate.
 This is the default timing mode if none is specified.
 .TP
 \fBtiming\fR best_effort ;
-Set the timing mode to try and keep up with interval between the traffic
-received.
-Unlike \fBkeep\fR, this mode will not warn about being unable to keep to
-the timings.
+This mode is deprecated and is the same as
+.IR keep .
+Will be removed in future major release.
 .TP
 \fBtiming\fR add NANOSECONDS ;
 Set the timing mode to add the given nanoseconds to the interval between

--- a/src/drool.h
+++ b/src/drool.h
@@ -76,10 +76,7 @@ struct drool {
     uint64_t            packets_dropped;
     uint64_t            packets_ignored;
 
-    struct timeval  last_packet;
-    struct timespec last_time;
-    struct timespec last_realtime;
-    struct timespec last_time_queue;
+    struct timespec mono_diff; /** add this value to convert from absolute value to mono time on this system */
 
     drool_client_pool_t* client_pool;
     drool_client_pool_t* client_pools;

--- a/src/drool.h
+++ b/src/drool.h
@@ -40,6 +40,7 @@
 
 #include "conf.h"
 #include "client_pool.h"
+#include "pcap-thread/pcap_thread.h"
 
 #include <stdint.h>
 #include <time.h>
@@ -61,7 +62,7 @@
 #define DROOL_T_INIT { \
     0, \
     0, 0, 0, 0, 0, \
-    { 0, 0 }, { 0, 0 }, { 0, 0 }, \
+    { 0, 0 }, { 0, 0 }, { 0, 0 }, 0, { 0, 0 }, \
     0, 0 \
 }
 /* clang-format on */
@@ -76,7 +77,11 @@ struct drool {
     uint64_t            packets_dropped;
     uint64_t            packets_ignored;
 
-    struct timespec mono_diff; /** add this value to convert from absolute value to mono time on this system */
+    struct timespec              diff;
+    struct timeval               last_pkthdr_ts;
+    struct timespec              last_ts;
+    pcap_thread_layer_callback_t timing_callback;
+    struct timespec              mod_ts;
 
     drool_client_pool_t* client_pool;
     drool_client_pool_t* client_pools;


### PR DESCRIPTION
Related: #75 

All timing is now absolute which avoids desynchronization.

This is proof-of-concept and it does not support some features:
- systems without absolute clock_nanosleep
- `timing multiply` option