### PR TITLE
Configure options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,15 @@ if test "x$ac_cv_path_DNSJIT" = "x"; then
   AC_MSG_ERROR([dnsjit was not found])
 fi
 
+# Check --enable-warn-all, placeholer for OARC projects wide options
+AC_ARG_ENABLE([warn-all])
+
+# Check --with-extra-cflags, placeholer for OARC projects wide options
+AC_ARG_WITH([extra-cflags])
+
+# Check --with-extra-ldflags, placeholer for OARC projects wide options
+AC_ARG_WITH([extra-ldflags])
+
 # Output Makefiles
 AC_CONFIG_FILES([
   Makefile

--- a/src/test/test2.sh
+++ b/src/test/test2.sh
@@ -36,8 +36,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 export LUA_PATH="$srcdir/../lib/?.lua"
-../drool -h
-../drool replay -h
 
 if [ -n "$DROOL_TEST_NETWORK" ]; then
     rm -f test2.out test2.out2


### PR DESCRIPTION
- `configure.ac`: Add placeholder for OARC projects configure options
  - Add `--enable-warn-all`
  - Add `--with-extra-cflags`
  - Add `--with-extra-ldflags`
- Remove test1 commands from test2