### PR TITLE
Packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ drool replay --no-tcp --no-responses --threads --udp-threads 3 file.pcap 127.0.0
 ## Dependencies
 
 `drool` is built upon [dnsjit](https://github.com/DNS-OARC/dnsjit) and
-requires it to be installed.
+requires it to be installed along with autoconf/automake.
 
 ## Build
 

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,15 @@ AC_ARG_WITH([extra-cflags])
 # Check --with-extra-ldflags, placeholer for OARC projects wide options
 AC_ARG_WITH([extra-ldflags])
 
+# Check --with-shebang
+AC_ARG_WITH([shebang], [AS_HELP_STRING([--with-shebang=shebang], [Set the shebang to use (without #!, default to /usr/bin/env dnsjit)])], [
+  AC_MSG_NOTICE([using shebang... $withval])
+  AC_SUBST([DROOL_SHEBANG], ["$withval"])
+], [
+  AC_MSG_NOTICE([using shebang... /usr/bin/env dnsjit])
+  AC_SUBST([DROOL_SHEBANG], ["/usr/bin/env dnsjit"])
+])
+
 # Output Makefiles
 AC_CONFIG_FILES([
   Makefile

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-drool (1.99.0-1.~unstable+1) unstable; urgency=low
+drool (1.99.1-5~unstable+1) unstable; urgency=low
 
-  * Release 1.99.0
+  * Release 1.99.1
 
     Alpha version using dnsjit.
 
- -- Jerry Lundström <lundstrom.jerry@gmail.com>  Wed, 11 Apr 2018 16:00:14 +0200
+ -- Jerry Lundström <lundstrom.jerry@gmail.com>  Thu, 05 Jul 2018 17:12:10 +0200
 
 drool (1.1.0-1~unstable+1) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -3,15 +3,15 @@ Section: net
 Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), build-essential, automake, autoconf,
- netbase, dnsjit
+ netbase, dnsjit (>= 0.9.4)
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/tools/drool
 Vcs-Git: https://github.com/DNS-OARC/drool.git
 Vcs-Browser: https://github.com/DNS-OARC/drool
 
 Package: drool
-Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Architecture: all
+Depends: ${misc:Depends}
 Description: DNS Replay Tool
  drool can replay DNS traffic from packet capture (PCAP) files and send it
  to a specified server, with options such as to manipulate the timing

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,3 +1,3 @@
 usr/share/man/man1
-usr/share/man/man5
+usr/share/drool
 usr/bin

--- a/rpm/drool.spec
+++ b/rpm/drool.spec
@@ -1,6 +1,6 @@
 Name:           drool
-Version:        1.99.0
-Release:        1.%{?dist}
+Version:        1.99.1
+Release:        5%{?dist}
 Summary:        DNS Replay Tool
 Group:          Productivity/Networking/DNS/Utilities
 
@@ -8,13 +8,24 @@ License:        BSD-3-Clause
 URL:            https://github.com/DNS-OARC/drool
 Source0:        %{name}_%{version}.orig.tar.gz
 
-BuildRequires:  dnsjit
+BuildArch:      noarch
+
+BuildRequires:  dnsjit >= 0.9.4
 BuildRequires:  autoconf
 BuildRequires:  automake
-BuildRequires:  libtool
+
+Requires:       dnsjit >= 0.9.4
+
 
 %description
-DNS Replay Tool
+drool can replay DNS traffic from packet capture (PCAP) files and send it
+to a specified server, with options such as to manipulate the timing
+between packets, as well as loop packets infinitely or for a set number of
+iterations. This tool's goal is to be able to produce a high amount of UDP
+packets per second and TCP sessions per second on common hardware.
+
+
+%define debug_package %{nil}
 
 
 %prep
@@ -23,7 +34,7 @@ DNS Replay Tool
 
 %build
 sh autogen.sh
-%configure
+%configure --with-shebang=/usr/bin/dnsjit
 make %{?_smp_mflags}
 
 
@@ -44,13 +55,13 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root)
 %{_bindir}/*
 %{_datadir}/doc/*
+%{_datadir}/drool
 %{_mandir}/man1/*
-%{_mandir}/man5/*
 
 
 %changelog
-* Wed Apr 11 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.99.0-1.
-- Release 1.99.0
+* Thu Jul 05 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.99.1-5
+- Release 1.99.1
   * Alpha version using dnsjit
 * Fri Feb 16 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.1.0-1
 - Release 1.1.0

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,7 +45,7 @@ EXTRA_DIST = drool.in \
   drool-replay.1in
 
 bin_SCRIPTS = drool
-droollibdir = $(pkglibdir)/drool
+droollibdir = $(datadir)/drool/lib/drool
 dist_droollib_DATA = lib/drool/replay.lua
 
 man1_MANS = drool.1 \
@@ -56,7 +56,8 @@ drool: drool.in Makefile
   -e 's,[@]PACKAGE_VERSION[@],$(PACKAGE_VERSION),g' \
   -e 's,[@]PACKAGE_URL[@],$(PACKAGE_URL),g' \
   -e 's,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g' \
-  -e 's,[@]pkglibdir[@],$(pkglibdir),g' \
+  -e 's,[@]droollibdir[@],$(datadir)/drool/lib,g' \
+  -e 's,[@]DROOL_SHEBANG[@],$(DROOL_SHEBANG),g' \
   < "$(srcdir)/drool.in" > drool
 	chmod +x drool
 

--- a/src/drool.in
+++ b/src/drool.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env dnsjit
+#!@DROOL_SHEBANG@
 -- DNS Reply Tool (drool)
 --
 -- Copyright (c) 2017-2018, OARC, Inc.
@@ -33,7 +33,7 @@
 -- LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 -- ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 -- POSSIBILITY OF SUCH DAMAGE.
-package.path = package.path .. ";@pkglibdir@/?.lua"
+package.path = package.path .. ";@droollibdir@/?.lua"
 
 local clock = require("dnsjit.lib.clock")
 local log = require("dnsjit.core.log").new("drool")


### PR DESCRIPTION
- Fix #111: Add configure option `--with-shebang`
  - Use `/usr/bin/dnsjit` for RPMs (according to rpmlint)
- Fix packages, now platform-independent