### PR TITLE
Dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-drool (1.99.1-5~unstable+1) unstable; urgency=low
+drool (1.99.1-7~unstable+1) unstable; urgency=low
 
   * Release 1.99.1
 
     Alpha version using dnsjit.
 
- -- Jerry Lundström <lundstrom.jerry@gmail.com>  Thu, 05 Jul 2018 17:12:10 +0200
+ -- Jerry Lundström <lundstrom.jerry@gmail.com>  Fri, 06 Jul 2018 14:42:03 +0200
 
 drool (1.1.0-1~unstable+1) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/DNS-OARC/drool
 
 Package: drool
 Architecture: all
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, dnsjit (>= 0.9.4)
 Description: DNS Replay Tool
  drool can replay DNS traffic from packet capture (PCAP) files and send it
  to a specified server, with options such as to manipulate the timing

--- a/rpm/drool.spec
+++ b/rpm/drool.spec
@@ -1,6 +1,6 @@
 Name:           drool
 Version:        1.99.1
-Release:        5%{?dist}
+Release:        7%{?dist}
 Summary:        DNS Replay Tool
 Group:          Productivity/Networking/DNS/Utilities
 
@@ -60,7 +60,7 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* Thu Jul 05 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.99.1-5
+* Fri Jul 06 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.99.1-7
 - Release 1.99.1
   * Alpha version using dnsjit
 * Fri Feb 16 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.1.0-1

--- a/src/lib/drool/replay.lua
+++ b/src/lib/drool/replay.lua
@@ -160,8 +160,15 @@ function Replay:setup(getopt)
                     local thrid = string.format("udp#%d", thr:pop())
                     local log = require("dnsjit.core.log").new(thrid)
                     require("dnsjit.core.objects")
-                    require("drool.replay_stats")
                     local ffi = require("ffi")
+                    local C = ffi.C
+ffi.cdef[[
+struct replay_stats {
+    int64_t sent, received, responses, timeouts, errors;
+};
+void* malloc(size_t);
+void free(void*);
+]]
                     local host = thr:pop()
                     local port = thr:pop()
                     local chan = thr:pop()
@@ -189,13 +196,13 @@ function Replay:setup(getopt)
                     urecv, uctx = udpcli:receive()
                     uprod = udpcli:produce()
 
-                    local stat = ffi.cast("struct replay_stats*", ffi.C.malloc(ffi.sizeof("struct replay_stats")))
+                    local stat = ffi.cast("struct replay_stats*", C.malloc(ffi.sizeof("struct replay_stats")))
                     stat.sent = 0
                     stat.received = 0
                     stat.responses = 0
                     stat.timeouts = 0
                     stat.errors = 0
-                    ffi.gc(stat, ffi.C.free)
+                    ffi.gc(stat, C.free)
 
                     local send
                     if resp == 0 then
@@ -291,7 +298,15 @@ function Replay:setup(getopt)
                     local thrid = string.format("tcp#%d", thr:pop())
                     local log = require("dnsjit.core.log").new(thrid)
                     require("dnsjit.core.objects")
-                    require("drool.replay_stats")
+                    local ffi = require("ffi")
+                    local C = ffi.C
+ffi.cdef[[
+struct replay_stats {
+    int64_t sent, received, responses, timeouts, errors;
+};
+void* malloc(size_t);
+void free(void*);
+]]
                     local ffi = require("ffi")
                     local host = thr:pop()
                     local port = thr:pop()
@@ -320,13 +335,13 @@ function Replay:setup(getopt)
                     trecv, tctx = tcpcli:receive()
                     tprod = tcpcli:produce()
 
-                    local stat = ffi.cast("struct replay_stats*", ffi.C.malloc(ffi.sizeof("struct replay_stats")))
+                    local stat = ffi.cast("struct replay_stats*", C.malloc(ffi.sizeof("struct replay_stats")))
                     stat.sent = 0
                     stat.received = 0
                     stat.responses = 0
                     stat.timeouts = 0
                     stat.errors = 0
-                    ffi.gc(stat, ffi.C.free)
+                    ffi.gc(stat, C.free)
 
                     local send
                     if resp == 0 then

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -37,7 +37,8 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
 CLEANFILES = test*.log test*.trs \
   *.pcap-dist \
-  test2.out test2.out2
+  test2.out test2.out2 \
+  test2-threads.out test2-threads.out2
 
 TESTS = test1.sh test2.sh
 

--- a/src/test/test2.sh
+++ b/src/test/test2.sh
@@ -35,16 +35,20 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-export LUA_PATH="$srcdir/../lib/?.lua"
+export LUA_PATH="$LUA_PATH;$srcdir/../lib/?.lua"
 
 if [ -n "$DROOL_TEST_NETWORK" ]; then
     rm -f test2.out test2.out2
     for pcap in ./dns.pcap-dist ./1qtcp.pcap-dist; do
         ../drool replay -n --no-tcp "$pcap" 127.0.0.1 53 | tail -n 7 >>test2.out
         ../drool replay -n --no-tcp "$pcap" ::1 53 | tail -n 7 >>test2.out
+        ../drool replay -T -n --no-tcp "$pcap" 127.0.0.1 53 | tail -n 7 >>test2-threads.out
+        ../drool replay -T -n --no-tcp "$pcap" ::1 53 | tail -n 7 >>test2-threads.out
     done
     awk '{print $1 " " $2}' <test2.out >test2.out2
     diff test2.out2 "$srcdir/test2.gold"
+    awk '{print $1 " " $2}' <test2-threads.out >test2-threads.out2
+    diff test2-threads.out2 "$srcdir/test2.gold"
 else
     echo "Not testing network (set DROOL_TEST_NETWORK to enable)"
 fi


### PR DESCRIPTION
- Fix runtime dependencies for Debian and Ubuntu
- `drool.replay`: Fix statistics structure when running threads
- `test2.sh`:
  - Don't overwrite system's `LUA_PATH`
  - Test with threads also