### PR TITLE
Respdiff fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 AC_PREREQ(2.61)
-AC_INIT([drool], [1.99.2], [admin@dns-oarc.net], [drool], [https://github.com/DNS-OARC/drool/issues])
+AC_INIT([drool], [1.99.3], [admin@dns-oarc.net], [drool], [https://github.com/DNS-OARC/drool/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_SRCDIR([src/drool.in])
 AC_CONFIG_MACRO_DIR([m4])
@@ -44,8 +44,8 @@ AC_PATH_PROG([DNSJIT],[dnsjit])
 AS_IF([test "x$ac_cv_path_DNSJIT" = "x"], [
   AC_MSG_ERROR([dnsjit was not found])
 ])
-AC_MSG_CHECKING([for dnsjit >= 0.9.5])
-AS_IF(["$DNSJIT" "$srcdir/dnsjit_version.lua" 0 9 5 2>/dev/null], [
+AC_MSG_CHECKING([for dnsjit >= 0.9.6])
+AS_IF(["$DNSJIT" "$srcdir/dnsjit_version.lua" 0 9 6 2>/dev/null], [
   AC_MSG_RESULT([yes])
 ], [
   AC_MSG_RESULT([no])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+drool (1.99.3-1~unstable+1) unstable; urgency=low
+
+  * Alpha release 1.99.3
+
+ -- Jerry Lundström <lundstrom.jerry@gmail.com>  Wed, 01 Aug 2018 11:46:31 +0200
+
 drool (1.99.2-1~unstable+1) unstable; urgency=low
 
   * Alpha release 1.99.2

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), build-essential, automake, autoconf,
- netbase, dnsjit (>= 0.9.5)
+ netbase, dnsjit (>= 0.9.6)
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/tools/drool
 Vcs-Git: https://github.com/DNS-OARC/drool.git
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/DNS-OARC/drool
 
 Package: drool
 Architecture: all
-Depends: ${misc:Depends}, dnsjit (>= 0.9.5)
+Depends: ${misc:Depends}, dnsjit (>= 0.9.6)
 Description: DNS Replay Tool
  drool can replay DNS traffic from packet capture (PCAP) files and send it
  to a specified server, with options such as to manipulate the timing

--- a/rpm/drool.spec
+++ b/rpm/drool.spec
@@ -1,5 +1,5 @@
 Name:           drool
-Version:        1.99.2
+Version:        1.99.3
 Release:        1%{?dist}
 Summary:        DNS Replay Tool
 Group:          Productivity/Networking/DNS/Utilities
@@ -10,11 +10,11 @@ Source0:        %{name}_%{version}.orig.tar.gz
 
 BuildArch:      noarch
 
-BuildRequires:  dnsjit >= 0.9.5
+BuildRequires:  dnsjit >= 0.9.6
 BuildRequires:  autoconf
 BuildRequires:  automake
 
-Requires:       dnsjit >= 0.9.5
+Requires:       dnsjit >= 0.9.6
 
 
 %description
@@ -60,6 +60,8 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Aug 01 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.99.3-1
+- Alpha release 1.99.3
 * Thu Jul 19 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.99.2-1
 - Alpha release 1.99.2
 * Fri Jul 06 2018 Jerry Lundström <lundstrom.jerry@gmail.com> 1.99.1-7

--- a/src/drool-respdiff.1in
+++ b/src/drool-respdiff.1in
@@ -100,6 +100,15 @@ Set the number of UDP threads to use, default 4.
 .TP
 .B \-\-timeout N.N
 Set timeout for waiting on responses [seconds.nanoseconds], default 10.0.
+.TP
+.B \-\-size BYTES
+Set the size (in bytes, multiple of OS page size) of the LMDB database, default 10485760.
+.SH DATABASE SIZE
+Note that you will need to set a database size that is large enough for all
+queries, all original responses, all received responses and all analysis done
+by
+.I respdiff
+tool-chain in order for a successful analysis to be done.
 .SH EXAMPLE
 This example replays a PCAP file against localhost and then uses the
 .I respdiff


### PR DESCRIPTION
- `drool.respdiff`:
  - Issue DNS-OARC/dnsjit#92: Add `--size` to set the database size
  - Rework the way to drain the channel of results when using threads and add a fail safe
- Alpha release v1.99.3